### PR TITLE
feat: Add allowSpacesInSuggestions parameter to AutocompleteTrigger

### DIFF
--- a/lib/src/autocomplete_trigger.dart
+++ b/lib/src/autocomplete_trigger.dart
@@ -17,6 +17,7 @@ class AutocompleteTrigger {
     required this.optionsViewBuilder,
     this.triggerOnlyAtStart = false,
     this.triggerOnlyAfterSpace = true,
+    this.allowSpacesInSuggestions = false,
     this.minimumRequiredCharacters = 0,
   });
 
@@ -30,6 +31,12 @@ class AutocompleteTrigger {
 
   /// Whether the [trigger] should only be recognised after a space.
   final bool triggerOnlyAfterSpace;
+
+  /// Whether the [trigger] should recognise autocomplete options
+  /// containing spaces. If set to true, suggestions like "@luke skywalker"
+  /// would be considered valid. If set to false, the first space character
+  /// would end the suggestion.
+  final bool allowSpacesInSuggestions;
 
   /// The minimum required characters for the [trigger] to start recognising
   /// a autocomplete options.
@@ -97,11 +104,16 @@ class AutocompleteTrigger {
     final suggestionEnd = cursorPosition;
     if (suggestionStart > suggestionEnd) return null;
 
-    // Fetch the suggestion text. The suggestions can't have spaces.
-    // valid example: "@luke_skywa..."
-    // invalid example: "@luke skywa..."
+    // Fetch the suggestion text.
     final suggestionText = text.substring(suggestionStart, suggestionEnd);
-    if (suggestionText.contains(' ')) return null;
+
+    // If [allowSpacesInSuggestions] is false, the suggestions can't have spaces.
+    // If true, suggestions like "@luke skywalker" would be considered valid.
+    // If false, suggestions like "@luke skywalker" would be considered invalid,
+    // and only examples like "@luke_skywalker" would be valid.
+    if (!allowSpacesInSuggestions && suggestionText.contains(' ')) {
+      return null;
+    }
 
     // A minimum number of characters can be provided to only show
     // suggestions after the customer has input enough characters.

--- a/lib/src/autocomplete_trigger.dart
+++ b/lib/src/autocomplete_trigger.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:multi_trigger_autocomplete/src/autocomplete_query.dart';
 
@@ -97,8 +99,10 @@ class AutocompleteTrigger {
     }
 
     // If the [trigger] is not at [firstTriggerIndexBeforeCursor], then it's not a trigger.
-    final triggerFromText = text.substring(firstTriggerIndexBeforeCursor,
-        firstTriggerIndexBeforeCursor + trigger.length);
+    final triggerFromText = text.substring(
+      firstTriggerIndexBeforeCursor,
+      min(firstTriggerIndexBeforeCursor + trigger.length, text.length),
+    );
     if (triggerFromText != trigger) {
       return null;
     }

--- a/test/autocomplete_trigger_test.dart
+++ b/test/autocomplete_trigger_test.dart
@@ -297,4 +297,65 @@ void main() {
       expect(trigger1, isNot(trigger2));
     });
   });
+
+  group('Autocomplete trigger with and without `allowSpacesInSuggestions`', () {
+    final triggerWithSpaces = AutocompleteTrigger(
+      trigger: '@',
+      allowSpacesInSuggestions: true,
+      optionsViewBuilder: (
+        context,
+        autocompleteQuery,
+        textEditingController,
+      ) {
+        return const SizedBox.shrink();
+      },
+    );
+
+    final triggerWithoutSpaces = AutocompleteTrigger(
+      trigger: '@',
+      allowSpacesInSuggestions: false,
+      optionsViewBuilder: (
+        context,
+        autocompleteQuery,
+        textEditingController,
+      ) {
+        return const SizedBox.shrink();
+      },
+    );
+
+    test(
+      'should return query if `@` is invoked and the word contains spaces when `allowSpacesInSuggestions` is true',
+      () {
+        const text = 'Hey @Sahil Kumar';
+        final invoked = triggerWithSpaces.invokingTrigger(
+          const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: text.length),
+          ),
+        );
+
+        expect(invoked, isNotNull);
+        expect(invoked!.query, 'Sahil Kumar');
+        expect(
+          invoked.selection,
+          const TextSelection(baseOffset: 5, extentOffset: 16),
+        );
+      },
+    );
+
+    test(
+      "should return null if `@` is invoked and the word contains spaces when `allowSpacesInSuggestions` is false",
+      () {
+        const text = 'Hey @Sahil Kumar';
+        final invoked = triggerWithoutSpaces.invokingTrigger(
+          const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: text.length),
+          ),
+        );
+
+        expect(invoked, isNull);
+      },
+    );
+  });
 }

--- a/test/autocomplete_trigger_test.dart
+++ b/test/autocomplete_trigger_test.dart
@@ -302,6 +302,7 @@ void main() {
     final triggerWithSpaces = AutocompleteTrigger(
       trigger: '@',
       allowSpacesInSuggestions: true,
+      triggers: {'@'},
       optionsViewBuilder: (
         context,
         autocompleteQuery,

--- a/test/autocomplete_trigger_test.dart
+++ b/test/autocomplete_trigger_test.dart
@@ -302,7 +302,7 @@ void main() {
     final triggerWithSpaces = AutocompleteTrigger(
       trigger: '@',
       allowSpacesInSuggestions: true,
-      triggers: {'@'},
+      triggerSet: {'@'},
       optionsViewBuilder: (
         context,
         autocompleteQuery,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR introduces a new parameter `allowSpacesInSuggestions` to the `AutocompleteTrigger` class. This allows the developer to choose whether the autocomplete suggestions can contain spaces or not. 

For example, by setting `allowSpacesInSuggestions` to `true`, a trigger for '@' after typing '@John ' could even suggest results that include a space, like 'John Doe'. 

The default behavior (i.e., without specifying `allowSpacesInSuggestions` or setting it to `false`) would be to return `null` as soon as a space is encountered after the trigger character, which means no suggestions are shown.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore