### PR TITLE
Adjust start offset calculation for query selection

### DIFF
--- a/lib/src/multi_trigger_autocomplete.dart
+++ b/lib/src/multi_trigger_autocomplete.dart
@@ -226,7 +226,7 @@ class MultiTriggerAutocompleteState extends State<MultiTriggerAutocomplete> {
     final text = _textEditingController.text;
 
     var start = querySelection.baseOffset;
-    if (!keepTrigger) start -= 1;
+    if (!keepTrigger) start -= _currentTrigger.trigger.length;
 
     final end = querySelection.extentOffset;
 

--- a/lib/src/multi_trigger_autocomplete.dart
+++ b/lib/src/multi_trigger_autocomplete.dart
@@ -226,7 +226,7 @@ class MultiTriggerAutocompleteState extends State<MultiTriggerAutocomplete> {
     final text = _textEditingController.text;
 
     var start = querySelection.baseOffset;
-    if (!keepTrigger) start -= _currentTrigger?.trigger.length;
+    if (!keepTrigger) start -= _currentTrigger?.trigger.length ?? 1;
 
     final end = querySelection.extentOffset;
 

--- a/lib/src/multi_trigger_autocomplete.dart
+++ b/lib/src/multi_trigger_autocomplete.dart
@@ -226,7 +226,7 @@ class MultiTriggerAutocompleteState extends State<MultiTriggerAutocomplete> {
     final text = _textEditingController.text;
 
     var start = querySelection.baseOffset;
-    if (!keepTrigger) start -= _currentTrigger.trigger.length;
+    if (!keepTrigger) start -= _currentTrigger?.trigger.length;
 
     final end = querySelection.extentOffset;
 

--- a/test/multi_trigger_autocomplete_test.dart
+++ b/test/multi_trigger_autocomplete_test.dart
@@ -297,6 +297,57 @@ void main() {
       expect(find.byKey(fieldKey), findsOneWidget);
       expect(find.byType(TextFormField), findsNothing);
     });
+
+    testWidgets('handles multi-character triggers with keepTrigger=false', (tester) async {
+      final multiCharTrigger = AutocompleteTrigger(
+        trigger: '##'
+        optionsViewBuilder: (context, query, controller) { },
+      );
+    
+      await tester.pumpWidget(
+        Boilerplate(
+          child: MultiTriggerAutocomplete(
+            autocompleteTriggers: [multiCharTrigger],
+          ),
+        ),
+      );
+    
+      await tester.enterText(find.byType(TextFormField), '##');
+      
+      await tester.tap(find.byType(InkWell).first);
+      await tester.pump();
+    
+      final TextFormField field = 
+        find.byType(TextFormField).evaluate().first.widget as TextFormField;
+      
+      expect(field.controller!.text, isNot(contains('##')));
+    });
+
+    testWidgets('cursor position correct after autocomplete with multi-character trigger', (tester) async {
+      final multiCharTrigger = AutocompleteTrigger(
+        trigger: '@@',
+        optionsViewBuilder: (context, query, controller) { },
+      );
+    
+      await tester.pumpWidget(
+        Boilerplate(
+          child: MultiTriggerAutocomplete(
+            autocompleteTriggers: [multiCharTrigger],
+          ),
+        ),
+      );
+    
+      await tester.enterText(find.byType(TextFormField), '@@sa');
+      
+      await tester.tap(find.byType(InkWell).first);
+      await tester.pump();
+    
+      final TextFormField field = 
+        find.byType(TextFormField).evaluate().first.widget as TextFormField;
+      
+      expect(field.controller!.selection.baseOffset, 
+             equals(field.controller!.text.length));
+    });
   });
 }
 

--- a/test/multi_trigger_autocomplete_test.dart
+++ b/test/multi_trigger_autocomplete_test.dart
@@ -323,21 +323,37 @@ void main() {
       expect(field.controller!.text, isNot(contains('##')));
     });
 
-    testWidgets('cursor position correct after autocomplete with multi-character trigger', (tester) async {
+     testWidgets('cursor position correct after autocomplete with multi-character trigger', (tester) async {
       final multiCharTrigger = AutocompleteTrigger(
         trigger: '@@',
-        optionsViewBuilder: (context, query, controller) { },
+        optionsViewBuilder: (context, query, controller) {
+          return ListView.builder(
+            itemCount: 1,
+            itemBuilder: (context, index) {
+              return ListTile(
+                title: const Text('Option'),
+                onTap: () {
+                  final autocomplete = MultiTriggerAutocomplete.of(context);
+                  return autocomplete.acceptAutocompleteOption('Option');
+                },
+              );
+            },
+          );
+        },
       );
     
       await tester.pumpWidget(
         Boilerplate(
           child: MultiTriggerAutocomplete(
+            debounceDuration: kDebounceDuration,
             autocompleteTriggers: [multiCharTrigger],
           ),
         ),
       );
     
       await tester.enterText(find.byType(TextFormField), '@@sa');
+      await tester.pumpAndSettle(kDebounceDuration);
+      expect(find.byType(ListView), findsOneWidget);
       
       await tester.tap(find.byType(InkWell).first);
       await tester.pump();


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

If trigger is longer than one character, `keepTrigger` doesn't work as expected. This fixes that :)

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Autocomplete now correctly removes multi-character trigger text when accepting a suggestion and places the cursor at the expected position.

* **Tests**
  * Added widget tests covering multi-character triggers, ensuring trigger text is removed and cursor position is correct after autocomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->